### PR TITLE
Fix: retain init buffer across resyncs for cached Options snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
 ## 2.12.2.dev (development stage/unreleased/unstable)
+### Fixed
+- `manager.py`: `binance.com-vanilla-options` depth caches never reached
+  the `synchronized` state because Binance's `/eapi/v1/depth` REST
+  endpoint serves a cached snapshot whose `lastUpdateId` can lag the
+  live diff stream by ~25–30 seconds. With the snapshot consistently
+  older than every buffered event, no event satisfied the
+  `U <= lastUpdateId <= u` sync predicate, and the previous replay
+  implementation dropped the init buffer on every failed attempt,
+  guaranteeing an endless resync loop. The init buffer is now retained
+  across resync attempts (pruned by `u < lastUpdateId` and capped at
+  10 000 entries), so once Binance's REST cache rotates far enough
+  forward, a previously buffered event matches the sync predicate and
+  the cache synchronises. Spot and Futures are unaffected because their
+  REST snapshots are live; behaviour for those exchanges is identical
+  when the first replay finds the sync point on the first try (the
+  common case). Post-sync events that were already in the buffer are
+  now applied via the regular gap-detection path (Spot:
+  `U == lastUpdateId + 1`, Futures/Options: `pu == lastUpdateId`)
+  instead of being silently discarded, which also closes a pre-existing
+  gap where fast initial bursts could leave the cache one or more
+  events behind immediately after sync.
 
 ## 2.12.2
 ### Changed

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -661,19 +661,66 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                     continue
                 # Replay buffered events from the init phase
                 if self.depth_caches[market].get('init_buffer'):
-                    buffered = self.depth_caches[market].pop('init_buffer')
+                    buffered = self.depth_caches[market]['init_buffer']
+                    self.depth_caches[market]['init_buffer'] = []
                     logger.info(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) - "
                                 f"Replaying {len(buffered)} buffered events for {market}")
                     buffered.append(stream_data)
+                    snapshot_last_update_id = self.depth_caches[market]['last_update_id']
+                    post_sync_applied = 0
+                    post_sync_gap = False
                     for buffered_event in buffered:
-                        if self.depth_caches[market]['is_synchronized'] is True:
-                            break
-                        self._process_init_event(stream_id=stream_id, stream_data=buffered_event, market=market)
-                    if self.depth_caches[market]['is_synchronized'] is not True:
+                        if self.depth_caches[market]['is_synchronized'] is not True:
+                            self._process_init_event(stream_id=stream_id, stream_data=buffered_event, market=market)
+                            continue
+                        # Already synced earlier in this loop: apply remaining events with gap detection
+                        if self.exchange == "binance.com" \
+                                or self.exchange == "binance.com-testnet" \
+                                or self.exchange == "binance.us" \
+                                or self.exchange == "trbinance.com":
+                            expected = self.depth_caches[market]['last_update_id'] + 1
+                            if int(buffered_event['data']['U']) != expected:
+                                post_sync_gap = True
+                                break
+                        elif self.exchange == "binance.com-futures" \
+                                or self.exchange == "binance.com-futures-testnet" \
+                                or self.exchange == "binance.com-vanilla-options" \
+                                or self.exchange == "binance.com-vanilla-options-testnet":
+                            if int(buffered_event['data']['pu']) != self.depth_caches[market]['last_update_id']:
+                                post_sync_gap = True
+                                break
+                        self._apply_updates(asks=buffered_event['data']['a'],
+                                            bids=buffered_event['data']['b'], market=market)
+                        self.depth_caches[market]['last_update_id'] = int(buffered_event['data']['u'])
+                        self.depth_caches[market]['last_update_time'] = int(time.time() * 1000)
+                        post_sync_applied += 1
+                    if post_sync_gap is True:
+                        logger.error(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) "
+                                     f"- Gap detected while replaying post-sync buffered events for `{market}`, "
+                                     f"requesting resync")
+                        self.set_resync_request(market=market)
+                    elif self.depth_caches[market]['is_synchronized'] is not True:
+                        # Keep buffered events for the next snapshot attempt. Required for exchanges
+                        # with a cached REST snapshot (Binance European Options) where the snapshot's
+                        # lastUpdateId can lag the stream by ~30s. Dropping the buffer on every failed
+                        # try would create an endless resync loop. Prune events definitely before the
+                        # snapshot (u < L) and cap the buffer size as a safeguard.
+                        if snapshot_last_update_id is not None:
+                            keep = [e for e in buffered
+                                    if int(e['data']['u']) >= snapshot_last_update_id]
+                        else:
+                            keep = list(buffered)
+                        max_buffer = 10000
+                        if len(keep) > max_buffer:
+                            keep = keep[-max_buffer:]
+                        self.depth_caches[market]['init_buffer'] = keep
                         logger.info(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) "
                                     f"- No sync point found in {len(buffered)} buffered events for {market}, "
-                                    f"requesting resync")
+                                    f"keeping {len(keep)} for retry, requesting resync")
                         self.set_resync_request(market=market)
+                    elif post_sync_applied > 0:
+                        logger.info(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) "
+                                    f"- Applied {post_sync_applied} post-sync buffered event(s) for `{market}`")
                     self.ubwa.asyncio_queue_task_done(stream_id=stream_id)
                     continue
                 self._process_init_event(stream_id=stream_id, stream_data=stream_data, market=market)


### PR DESCRIPTION
## Problem

`binance.com-vanilla-options` depth caches never reach the
`synchronized` state. The `error_id #6000 "DepthCache '<symbol>' for
'binance.com-vanilla-options' is out of sync"` response is returned
indefinitely, and the UBDCC cluster reports the underlying UBLDC caches
as `running` but permanently out of sync.

## Root cause

Binance's Options REST endpoint `/eapi/v1/depth` serves a **cached
snapshot** whose `lastUpdateId` can lag the live diff stream by ~25–30
seconds. Verified live on 2026-04-19:

```
T=...111  snapshot_T=...086  lastUpdateId=15034796780  age=24.5s
T=...112  snapshot_T=...086  lastUpdateId=15034796780  age=25.8s
T=...113  snapshot_T=...086  lastUpdateId=15034796780  age=27.1s
T=...115  snapshot_T=...109  lastUpdateId=15034834333  age= 5.1s   # cache rotated
```

Consequence: every buffered WS event has `U > lastUpdateId`, so no
event ever satisfies the Binance sync predicate `U <= lastUpdateId <= u`.
The previous replay code then `.pop()`ed the init buffer and requested
a resync. Because the buffer was discarded, the next snapshot attempt
started with an empty buffer holding only *newer* events — guaranteeing
the same failure on the next try. Endless resync loop.

Example from a debug run:
```
Finished initialization, lastUpdateId=15034618453, 1 events buffered!
No sync point in event: U=15034622400, u=15034623014, lastUpdateId=15034618453
No sync point in event: U=15034623059, u=15034623059, lastUpdateId=15034618453
No sync point found in 2 buffered events, requesting resync
```

## Fix

Retain the init buffer across resync attempts rather than discarding
it on each failed try. Events with `u < lastUpdateId` (definitely before
the snapshot) are pruned; the buffer is capped at 10 000 entries as a
safeguard against pathological growth. Once Binance's REST cache
rotates far enough forward, a previously buffered event overlaps the
snapshot, the sync predicate matches, and the cache synchronises.

Additionally, post-sync events that were already in the replay buffer
are now applied via the regular gap-detection path (Spot:
`U == lastUpdateId + 1`, Futures/Options: `pu == lastUpdateId`) instead
of being silently discarded — this closes a pre-existing gap where a
fast initial burst could leave the cache one or more events behind
immediately after sync.

## Why not alternative fixes

- **Snapshot-first, then WS**: races against updates that happen
  between the REST response and the WS subscribe going active — those
  are silently lost. Not consistent.
- **Retry until snapshot age < 2 s**: age is not continuity. A
  young snapshot can still miss the stream's current position. Treats
  the symptom, not the cause.
- **Different sync predicate (e.g. `pu == L`)**: does not help on its
  own. The first event after a cached snapshot has `pu` > `L` just as
  much as `U` > `L`; the lag is the actual problem, and the only
  correct response is to wait for the cache to rotate.

## Scope / risk

- Spot / Futures: behaviour is unchanged when the first replay finds
  the sync point on the first try (the common case). In the rare case
  where it does not, the buffer is now retained instead of dropped,
  which is strictly an improvement (same or better).
- Options: goes from "never syncs" to "syncs within ~8 s in tests".

## Tested

Live on Binance production:

| Exchange | Markets | Result before | Result after |
|---|---|---|---|
| `binance.com-vanilla-options` | `BTC-260626-100000-C` | never syncs | syncs in ~8 s, stable |
| `binance.com` | `BTCUSDT`, `ETHUSDT`, `BNBUSDT` | OK | OK |
| `binance.com-futures` | `BTCUSDT`, `ETHUSDT` | OK | OK |

## Files changed

- `unicorn_binance_local_depth_cache/manager.py`: init-buffer retention
  + post-sync buffered-event replay with gap detection.
- `CHANGELOG.md`: entry under `2.12.2.dev`.