### PR TITLE
Bump version to 2.12.3

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -107,7 +107,7 @@ jobs:
           generate_release_notes: true
           name: unicorn-binance-local-depth-cache
           prerelease: false
-          tag_name: 2.12.2
+          tag_name: 2.12.3
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
 
 Python SDK (MIT License) for building and managing multiple local Binance order book depth caches. Subscribes to Binance WebSocket diff streams, initializes via REST snapshots, and maintains a synchronized in-process order book (asks/bids) per market.
 
-**Current Version:** 2.12.2
+**Current Version:** 2.12.3
 **Python Compatibility:** 3.9 – 3.14  
 **Author:** Oliver Zehentleitner  
 **PyPI:** `unicorn-binance-local-depth-cache`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
+## 2.12.3.dev (development stage/unreleased/unstable)
+
 ## 2.12.3
 ### Fixed
 - `manager.py`: `binance.com-vanilla-options` depth caches never reached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
-## 2.12.2.dev (development stage/unreleased/unstable)
+## 2.12.3
 ### Fixed
 - `manager.py`: `binance.com-vanilla-options` depth caches never reached
   the `synchronized` state because Binance's `/eapi/v1/depth` REST

--- a/README.md
+++ b/README.md
@@ -291,10 +291,10 @@ Run in bash:
 `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
 
 #### Windows
-Use the below command with the version (such as 2.12.2) you determined 
+Use the below command with the version (such as 2.12.3) you determined 
 [here](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest):
 
-`pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.2.tar.gz --upgrade`
+`pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.3.tar.gz --upgrade`
 
 ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
 This is not a release version and can not be considered to be stable!

--- a/dev/set_version_config.txt
+++ b/dev/set_version_config.txt
@@ -1,2 +1,2 @@
-2.12.2
+2.12.3
 meta.yaml,pyproject.toml,setup.py,README.md,.github/workflows/build_wheels.yml,dev/sphinx/source/conf.py,unicorn_binance_local_depth_cache/manager.py,AGENTS.md

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -27,7 +27,7 @@ author = 'Oliver Zehentleitner'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.12.2'
+release = '2.12.3'
 
 html_last_updated_fmt = "%b %d %Y at %H:%M (CET)"
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-local-depth-cache" %}
-{% set version = "2.12.2" %}
+{% set version = "2.12.3" %}
 
 package:
   name: {{ name|lower }}
@@ -339,10 +339,10 @@ about:
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
     
     #### Windows
-    Use the below command with the version (such as 2.12.2) you determined 
+    Use the below command with the version (such as 2.12.3) you determined
     [here](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest):
     
-    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.2.tar.gz --upgrade`
+    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.3.tar.gz --upgrade`
     
     ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
     This is not a release version and can not be considered to be stable!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unicorn-binance-local-depth-cache"
-version = "2.12.2"
+version = "2.12.3"
 description = "A Python SDK for accessing and managing multiple local Binance order books with Python in a simple, fast, flexible, robust and fully featured way."
 authors = ["Oliver Zehentleitner"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ with open("README.md", "r") as fh:
 
 setup(
      name=name,
-     version="2.12.2",
+     version="2.12.3",
      author="Oliver Zehentleitner",
      author_email='',
      url="https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache",

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -54,7 +54,7 @@ import threading
 
 
 __app_name__: str = "unicorn-binance-local-depth-cache"
-__version__: str = "2.12.2.dev"
+__version__: str = "2.12.3"
 __logger__: logging.getLogger = logging.getLogger("unicorn_binance_local_depth_cache")
 
 logger = __logger__


### PR DESCRIPTION
Release of the Options snapshot-cache sync fix (#98).

## Version bumps (2.12.2 → 2.12.3)

Files covered by `dev/set_version_config.txt`, done by hand rather than
via `set_version.py` to avoid rewriting the matching `2.12.2` string in
the UBWA dependency pins.

- `meta.yaml` – package version + install snippet
- `pyproject.toml` – `version`
- `setup.py` – `version`
- `README.md` – install snippet
- `.github/workflows/build_wheels.yml` – `tag_name`
- `dev/sphinx/source/conf.py` – `release`
- `unicorn_binance_local_depth_cache/manager.py` – `__version__` (was `2.12.2.dev`)
- `AGENTS.md` – `Current Version`
- `dev/set_version_config.txt` – baseline

## Dependencies left untouched

- `unicorn-binance-websocket-api >= 2.12.2` (released)
- `unicorn-binance-rest-api >= 2.10.0` (released)

Verified with `grep` that the only remaining `2.12.2` occurrences in
the suite's config files are the UBWA pins in `meta.yaml`,
`pyproject.toml`, `setup.py`, `requirements.txt` and `environment.yml`
plus the historical CHANGELOG entries — all intentional.

## CHANGELOG

The former `2.12.2.dev` section (Options sync fix) is promoted to
`## 2.12.3`.