### PR TITLE
Add BinanceLocalDepthCacheManager.set_credentials() for runtime key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
 ## 2.12.3.dev (development stage/unreleased/unstable)
+### Added
+- `manager.py`: New `set_credentials(api_key, api_secret)` method on
+  `BinanceLocalDepthCacheManager` — swap the internal
+  `BinanceRestApiManager` to a fresh instance bound to the given credentials
+  at runtime, without recreating the depth cache manager or interrupting
+  the WebSocket streams. New credentials take effect from the next REST
+  call (snapshot / resync). Pass `None` / `None` to drop credentials and
+  fall back to public rate limits. Enables UBDCC DCNs to react to
+  credential rebalances pushed from the cluster management.
 
 ## 2.12.3
 ### Fixed

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
 ## 2.12.3.dev (development stage/unreleased/unstable)
+### Added
+- `manager.py`: New `set_credentials(api_key, api_secret)` method on
+  `BinanceLocalDepthCacheManager` — swap the internal
+  `BinanceRestApiManager` to a fresh instance bound to the given credentials
+  at runtime, without recreating the depth cache manager or interrupting
+  the WebSocket streams. New credentials take effect from the next REST
+  call (snapshot / resync). Pass `None` / `None` to drop credentials and
+  fall back to public rate limits. Enables UBDCC DCNs to react to
+  credential rebalances pushed from the cluster management.
 
 ## 2.12.3
 ### Fixed

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -155,6 +155,7 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         self.websocket_ping_interval = websocket_ping_interval
         self.websocket_ping_timeout = websocket_ping_timeout
         self.disable_colorama = disable_colorama
+        self.warn_on_update = warn_on_update
         self.ubdcc_address = ubdcc_address
         self.ubdcc_port = ubdcc_port
         self.last_update_check_github: dict = {'timestamp': time.time(), 'status': {'tag_name': None}}
@@ -1237,6 +1238,33 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         :return: BinanceRestApiManager
         """
         return self.ubra
+
+    def set_credentials(self, api_key: str = None, api_secret: str = None) -> None:
+        """
+        Replace the internal BinanceRestApiManager with a fresh instance bound to the given
+        credentials. Use this to rotate API keys at runtime without recreating the
+        BinanceLocalDepthCacheManager or interrupting the WebSocket streams — the new
+        credentials take effect from the next REST call (initial snapshot, resync).
+
+        Pass ``api_key=None`` and ``api_secret=None`` to drop credentials and fall back
+        to the public rate limits.
+
+        :param api_key: Binance API key, or ``None`` to use public rate limits
+        :type api_key: str
+        :param api_secret: Binance API secret, or ``None`` to use public rate limits
+        :type api_secret: str
+        """
+        old_ubra = self.ubra
+        self.ubra = BinanceRestApiManager(api_key=api_key,
+                                          api_secret=api_secret,
+                                          exchange=self.exchange,
+                                          disable_colorama=self.disable_colorama,
+                                          warn_on_update=self.warn_on_update)
+        if old_ubra is not None:
+            try:
+                old_ubra.stop_manager()
+            except Exception as error_msg:
+                logger.warning(f"set_credentials() - failed to stop previous ubra instance: {error_msg}")
 
     def get_ubwa_manager(self) -> BinanceWebSocketApiManager:
         """


### PR DESCRIPTION
## Summary
- New public method \`set_credentials(api_key, api_secret)\` on \`BinanceLocalDepthCacheManager\` — swap the internal \`BinanceRestApiManager\` at runtime without recreating the depth cache manager or interrupting the WebSocket streams.
- The new credentials take effect from the next REST call (initial snapshot / resync).
- Pass \`api_key=None\` and \`api_secret=None\` to drop credentials and fall back to the public rate limits.
- Also persists \`warn_on_update\` on self so the replacement \`BinanceRestApiManager\` can be built with the same settings as the initial one.

## Motivation
Enables UBDCC DCNs to react to credential rebalances pushed from the cluster management without dropping or restarting depth caches. Currently they can't, which is why a recently observed cluster ends up with \`assigned_dcns: []\` after a DCN restart and never recovers.

## Test plan
- [ ] Run the existing unit suite against binance.com (\`coverage run --source unicorn_binance_local_depth_cache unittest_binance_local_depth_cache.py\`) — verify no regressions
- [ ] Manual: in a running \`BinanceLocalDepthCacheManager\`, call \`set_credentials(\"k\", \"s\")\`, then \`get_ubra_manager().API_KEY\` == \"k\", streams still running

## Notes
- Dev-header in CHANGELOG still reads \`2.12.3.dev\` — that bump to \`2.12.4.dev\` is a post-release housekeeping step for you; I didn't touch versions.