### PR TITLE
Bump version to 2.13.0

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -107,7 +107,7 @@ jobs:
           generate_release_notes: true
           name: unicorn-binance-local-depth-cache
           prerelease: false
-          tag_name: 2.12.3
+          tag_name: 2.13.0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
 
 Python SDK (MIT License) for building and managing multiple local Binance order book depth caches. Subscribes to Binance WebSocket diff streams, initializes via REST snapshots, and maintains a synchronized in-process order book (asks/bids) per market.
 
-**Current Version:** 2.12.3
+**Current Version:** 2.13.0
 **Python Compatibility:** 3.9 – 3.14  
 **Author:** Oliver Zehentleitner  
 **PyPI:** `unicorn-binance-local-depth-cache`  

--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ Run in bash:
 `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
 
 #### Windows
-Use the below command with the version (such as 2.12.3) you determined 
+Use the below command with the version (such as 2.13.0) you determined 
 [here](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest):
 
-`pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.3.tar.gz --upgrade`
+`pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.13.0.tar.gz --upgrade`
 
 ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
 This is not a release version and can not be considered to be stable!

--- a/dev/set_version_config.txt
+++ b/dev/set_version_config.txt
@@ -1,2 +1,2 @@
-2.12.3
+2.13.0
 meta.yaml,pyproject.toml,setup.py,README.md,.github/workflows/build_wheels.yml,dev/sphinx/source/conf.py,unicorn_binance_local_depth_cache/manager.py,AGENTS.md

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -27,7 +27,7 @@ author = 'Oliver Zehentleitner'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.12.3'
+release = '2.13.0'
 
 html_last_updated_fmt = "%b %d %Y at %H:%M (CET)"
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-local-depth-cache" %}
-{% set version = "2.12.3" %}
+{% set version = "2.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -339,10 +339,10 @@ about:
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
     
     #### Windows
-    Use the below command with the version (such as 2.12.3) you determined
+    Use the below command with the version (such as 2.13.0) you determined
     [here](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/latest):
     
-    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.12.3.tar.gz --upgrade`
+    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/archive/2.13.0.tar.gz --upgrade`
     
     ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
     This is not a release version and can not be considered to be stable!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unicorn-binance-local-depth-cache"
-version = "2.12.3"
+version = "2.13.0"
 description = "A Python SDK for accessing and managing multiple local Binance order books with Python in a simple, fast, flexible, robust and fully featured way."
 authors = ["Oliver Zehentleitner"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ with open("README.md", "r") as fh:
 
 setup(
      name=name,
-     version="2.12.3",
+     version="2.13.0",
      author="Oliver Zehentleitner",
      author_email='',
      url="https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache",

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -54,7 +54,7 @@ import threading
 
 
 __app_name__: str = "unicorn-binance-local-depth-cache"
-__version__: str = "2.12.3.dev"
+__version__: str = "2.13.0"
 __logger__: logging.getLogger = logging.getLogger("unicorn_binance_local_depth_cache")
 
 logger = __logger__


### PR DESCRIPTION
## Summary
Release bump from 2.12.3 / 2.12.3.dev to **2.13.0** — targets the files listed in \`dev/set_version_config.txt\`:

- \`meta.yaml\` (jinja var + two doc examples)
- \`pyproject.toml\`
- \`setup.py\`
- \`README.md\` (two doc examples)
- \`.github/workflows/build_wheels.yml\` (tag_name)
- \`dev/sphinx/source/conf.py\` (release)
- \`unicorn_binance_local_depth_cache/manager.py\` (\`__version__\`, \`.dev\` suffix dropped)
- \`AGENTS.md\`
- \`dev/set_version_config.txt\` (version pointer)

CHANGELOG is already at \`2.13.0\` (your previous commit).

## Test plan
- [x] \`grep -rn "2\.12\.3"\` returns zero hits in the listed files
- [ ] CI build on merge produces wheels tagged 2.13.0