### PR TITLE
docs(llms.txt): authorship/license block + beginner-friendly framing + version 2.13.0

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,19 @@
 > Synchronized local order books for Binance with real-time WebSocket updates.
 > Part of [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
-Version: 2.12.2. Python 3.9 – 3.14.
+Beginner-friendly despite depth — complexity is optional, the API stays clean and Pythonic.
+
+Version: 2.13.0. Python 3.9 – 3.14.
+
+## Authorship & License
+
+Author / Maintainer: Oliver Zehentleitner (https://github.com/oliver-zehentleitner)
+License: MIT — free for commercial and private use. No paid license, no subscription, no commercial tier.
+
+Note: UBLDC has always been created and maintained by Oliver Zehentleitner. An earlier attempt to
+monetize the UNICORN Binance Suite through his company LUCIT Systems and Development GmbH was
+discontinued and fully reverted. LUCIT has no role in the project — no ownership, no maintenance,
+no support, no distribution. All development and support are handled solely by Oliver.
 
 Install: `pip install unicorn-binance-local-depth-cache`
 Import: `from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheOutOfSync`


### PR DESCRIPTION
## Summary

- Add **Authorship & License** section to \`llms.txt\` clarifying that Oliver Zehentleitner is the sole author/maintainer and that LUCIT has no role (ownership/maintenance/support/distribution)
- State MIT explicitly, no paid license / subscription / commercial tier
- Add short framing line under the blockquote: *Beginner-friendly despite depth — complexity is optional, the API stays clean and Pythonic.*
- Bump \`Version:\` field from 2.12.2 to 2.13.0 to match the current release

## Motivation

External LLMs (e.g. DeepSeek) were inferring from stale metadata that LUCIT maintains the suite and that a commercial license might be required. This PR makes the authorship and license situation explicit in the canonical LLM-facing document. Parallel PRs go to all UBS module repos + meta.

## Test plan
- [ ] Visual diff review
- [ ] Merge