### PR TITLE
fix: add Binance margin exchange support to REST snapshot and sync paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
-## 2.13.0.dev (development stage/unreleased/unstable)
+## 2.13.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `manager.py`: REST snapshot support for Binance margin exchanges. The
+  exchange switch in `_get_order_book_from_rest()` had no case for
+  `binance.com-margin`, `binance.com-margin-testnet`,
+  `binance.com-isolated_margin` and `binance.com-isolated_margin-testnet`,
+  so the snapshot returned `None` and the DepthCache never reached the
+  `synchronized` state. Margin markets use the spot REST endpoint
+  (`/api/v3/depth`) and the spot WebSocket diff-depth format (`U/u`),
+  so they are now routed through the same code path as `binance.com`
+  across all four exchange switches in `manager.py` (snapshot fetch,
+  live-update gap detection, post-sync buffer replay gap detection,
+  and init-phase sync-point detection).
 
 ## 2.13.0
 ### Added

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -9,7 +9,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
-## 2.13.0.dev (development stage/unreleased/unstable)
+## 2.13.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `manager.py`: REST snapshot support for Binance margin exchanges. The
+  exchange switch in `_get_order_book_from_rest()` had no case for
+  `binance.com-margin`, `binance.com-margin-testnet`,
+  `binance.com-isolated_margin` and `binance.com-isolated_margin-testnet`,
+  so the snapshot returned `None` and the DepthCache never reached the
+  `synchronized` state. Margin markets use the spot REST endpoint
+  (`/api/v3/depth`) and the spot WebSocket diff-depth format (`U/u`),
+  so they are now routed through the same code path as `binance.com`
+  across all four exchange switches in `manager.py` (snapshot fetch,
+  live-update gap detection, post-sync buffer replay gap detection,
+  and init-phase sync-point detection).
 
 ## 2.13.0
 ### Added

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -69,8 +69,9 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         - https://binance-docs.github.io/apidocs/spot/en/#how-to-manage-a-local-order-book-correctly
         - https://binance-docs.github.io/apidocs/futures/en/#diff-book-depth-streams
 
-    :param exchange: Select binance.com, binance.com-testnet, binance.com-futures, binance.com-futures-testnet,
-                     binance.com-vanilla-options, binance.com-vanilla-options-testnet,
+    :param exchange: Select binance.com, binance.com-testnet, binance.com-margin, binance.com-margin-testnet,
+                     binance.com-isolated_margin, binance.com-isolated_margin-testnet, binance.com-futures,
+                     binance.com-futures-testnet, binance.com-vanilla-options, binance.com-vanilla-options-testnet,
                      binance.us, trbinance.com (default: binance.com)
     :type exchange: str
     :param default_refresh_interval: The default refresh interval in seconds, default is None. The DepthCache is reset
@@ -401,6 +402,10 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         try:
             if self.exchange == "binance.com" \
                     or self.exchange == "binance.com-testnet" \
+                    or self.exchange == "binance.com-margin" \
+                    or self.exchange == "binance.com-margin-testnet" \
+                    or self.exchange == "binance.com-isolated_margin" \
+                    or self.exchange == "binance.com-isolated_margin-testnet" \
                     or self.exchange == "binance.us" \
                     or self.exchange == "trbinance.com":
                 order_book = self.ubra.get_order_book(symbol=market.upper(), limit=1000)
@@ -609,6 +614,10 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                 # Gap detection
                 if self.exchange == "binance.com" \
                         or self.exchange == "binance.com-testnet" \
+                        or self.exchange == "binance.com-margin" \
+                        or self.exchange == "binance.com-margin-testnet" \
+                        or self.exchange == "binance.com-isolated_margin" \
+                        or self.exchange == "binance.com-isolated_margin-testnet" \
                         or self.exchange == "binance.us" \
                         or self.exchange == "trbinance.com":
                     if stream_data['data']['U'] != self.depth_caches[market]['last_update_id']+1:
@@ -677,6 +686,10 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                         # Already synced earlier in this loop: apply remaining events with gap detection
                         if self.exchange == "binance.com" \
                                 or self.exchange == "binance.com-testnet" \
+                                or self.exchange == "binance.com-margin" \
+                                or self.exchange == "binance.com-margin-testnet" \
+                                or self.exchange == "binance.com-isolated_margin" \
+                                or self.exchange == "binance.com-isolated_margin-testnet" \
                                 or self.exchange == "binance.us" \
                                 or self.exchange == "trbinance.com":
                             expected = self.depth_caches[market]['last_update_id'] + 1
@@ -740,6 +753,10 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         """
         if self.exchange == "binance.com" \
                 or self.exchange == "binance.com-testnet" \
+                or self.exchange == "binance.com-margin" \
+                or self.exchange == "binance.com-margin-testnet" \
+                or self.exchange == "binance.com-isolated_margin" \
+                or self.exchange == "binance.com-isolated_margin-testnet" \
                 or self.exchange == "binance.us" \
                 or self.exchange == "trbinance.com":
             if int(stream_data['data']['u']) <= self.depth_caches[market]['last_update_id']:


### PR DESCRIPTION
## Summary

Margin DepthCaches never reach the `synchronized` state because every exchange switch in `manager.py` treats `binance.com-margin`, `binance.com-margin-testnet`, `binance.com-isolated_margin`, and `binance.com-isolated_margin-testnet` as unsupported and falls into the `else` branch.

Four locations are affected:

| Location | Effect of missing margin case |
|---|---|
| `_get_order_book_from_rest()` (L402) | `order_book = None` → no snapshot → DC never initialises |
| Live-update gap detection (L610) | Gap check skipped, no resync trigger |
| Post-sync buffer replay gap detection (L678) | Buffered events applied without gap check |
| `_process_init_event()` sync-point search (L741) | No sync predicate evaluated → cache never flips to synced |

## Why spot-equivalent

Binance margin trading reuses the spot order book. For depth data:

- REST: `https://api.binance.com/api/v3/depth` — same endpoint as spot (UBRA routes `binance.com-margin` to `API_URL = https://api.binance.com/api`)
- WebSocket: `wss://stream.binance.com:9443/...@depth@...` — spot stream infrastructure (UBWA `connection_settings.py:86-89`)
- Update format: spot `U/u` diff-depth (not futures `pu`)

Margin variants are therefore routed through the exact same code path as `binance.com` / `binance.com-testnet` in all four switches.

## Changes

- `unicorn_binance_local_depth_cache/manager.py`:
  - Four exchange switches extended with the 4 margin variants
  - `__init__` docstring updated to list margin exchanges
- `CHANGELOG.md` + `dev/sphinx/source/changelog.md`: bumped dev header to `2.13.1.dev`, added Fixed entry

## Test plan

- [ ] `ubdcc create-depthcache --exchange binance.com-margin --market BTCUSDT` reaches `running` with `is_synchronized=true`
- [ ] Same for `binance.com-isolated_margin`
- [ ] `binance.com-margin-testnet` on testnet
- [ ] Existing spot / futures / options caches continue to sync (regression check)
- [ ] Gap detection still triggers resync on all exchanges