### PR TITLE
docs: list margin and isolated_margin (mainnet + testnet) in supported-exchanges table

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ except DepthCacheClusterNotReachableError as error_msg:
 The Python package [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) 
 provides local order books for the Binance Exchanges 
 [Binance](https://github.com/binance-exchange/binance-official-api-docs) ([+Testnet](https://testnet.binance.vision/)), 
+Binance Cross Margin and Isolated Margin (+Testnet),
 [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
 ([+Testnet](https://testnet.binancefuture.com)),
 [Binance European Options](https://developers.binance.com/docs/derivatives/option/general-info)
@@ -206,6 +207,10 @@ is thrown or ask with [`is_depth_cache_synchronized()`](https://oliver-zehentlei
 |--------------------------------------------------------------------|-------------------------------| 
 | [Binance](https://www.binance.com)                                 | `binance.com`                 |
 | [Binance Testnet](https://testnet.binance.vision/)                 | `binance.com-testnet`         |
+| [Binance Cross Margin](https://www.binance.com)                    | `binance.com-margin`          |
+| [Binance Cross Margin Testnet](https://testnet.binance.vision/)    | `binance.com-margin-testnet`  |
+| [Binance Isolated Margin](https://www.binance.com)                 | `binance.com-isolated_margin` |
+| [Binance Isolated Margin Testnet](https://testnet.binance.vision/) | `binance.com-isolated_margin-testnet` |
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -154,6 +154,7 @@ except DepthCacheClusterNotReachableError as error_msg:
 The Python package [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) 
 provides local order books for the Binance Exchanges 
 [Binance](https://github.com/binance-exchange/binance-official-api-docs) ([+Testnet](https://testnet.binance.vision/)), 
+Binance Cross Margin and Isolated Margin (+Testnet),
 [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
 ([+Testnet](https://testnet.binancefuture.com)),
 [Binance European Options](https://developers.binance.com/docs/derivatives/option/general-info)
@@ -206,6 +207,10 @@ is thrown or ask with [`is_depth_cache_synchronized()`](https://oliver-zehentlei
 |--------------------------------------------------------------------|-------------------------------| 
 | [Binance](https://www.binance.com)                                 | `binance.com`                 |
 | [Binance Testnet](https://testnet.binance.vision/)                 | `binance.com-testnet`         |
+| [Binance Cross Margin](https://www.binance.com)                    | `binance.com-margin`          |
+| [Binance Cross Margin Testnet](https://testnet.binance.vision/)    | `binance.com-margin-testnet`  |
+| [Binance Isolated Margin](https://www.binance.com)                 | `binance.com-isolated_margin` |
+| [Binance Isolated Margin Testnet](https://testnet.binance.vision/) | `binance.com-isolated_margin-testnet` |
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |


### PR DESCRIPTION
## Summary

Follow-up to #105. Runtime support for the four margin variants landed there; the README had not yet been updated to advertise them.

## Changes

- `README.md`
  - "Supported Exchanges" table: four new rows — cross/isolated × mainnet/testnet
  - Opening description paragraph: mentions Binance Cross Margin and Isolated Margin (+Testnet) alongside spot/futures/options
- `dev/sphinx/source/readme.md`: mirrored

## Why

Users need to see which exchange strings are accepted before they try them. With #105 merged, `binance.com-margin`, `binance.com-margin-testnet`, `binance.com-isolated_margin` and `binance.com-isolated_margin-testnet` all work, but the README still implied only spot/futures/options/us/tr were supported.