### PR TITLE
fix(setup): read README.md with UTF-8 encoding (Windows build)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ else:
     shutil.rmtree(os.path.join(stubs_dir))
     print("Stub files generated and moved successfully.")
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     print("Using README.md content as `long_description` ...")
     long_description = fh.read()
 


### PR DESCRIPTION
## Summary

The 2.14.0 release build fails on Windows because `setup.py` opens `README.md` without an explicit encoding, so Python falls back to the platform default (`cp1252` on Windows). Since the README's line 1 now contains the security-warning banner with a non-cp1252 character (⚠️), the decode blows up:

```
File "<string>", line 61, in <module>
File ".../cp1252.py", line 23, in decode
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 7
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

Linux and macOS default to UTF-8 so only Windows was affected.

## Fix

One line: `open("README.md", "r", encoding="utf-8") as fh`.

Portable, explicit, works across platforms. No change in behaviour where it already worked.

## Test plan

- [ ] `Build and Publish GH+PyPi` workflow succeeds on ubuntu-24.04 / windows-2025 / macos-14
- [ ] PyPI receives 2.14.0 sdist + wheels