### PR TITLE
docs(README): add depthcache rot + UBDCC deep-dive articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ This is not a release version and can not be considered to be stable!
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [Why Your Binance Order Book Should Not Live Inside Your Bot](https://blog.technopathy.club/why-your-binance-order-book-should-not-live-inside-your-bot)
 - [Your Binance Order Book Is Wrong — Here's Why](https://blog.technopathy.club/your-binance-order-book-is-wrong-here-s-why)
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours)
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 
 ## Project Homepage

--- a/llms.txt
+++ b/llms.txt
@@ -128,6 +128,11 @@ Returns: `list` of `[price, quantity]` pairs. Raises `DepthCacheOutOfSync` if ca
 - [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST client used internally for depth snapshots. Share via `ubra_manager=...`.
 - [UBDCC](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) — distributed, horizontally scalable cluster of UBLDC instances with load balancing, failover and REST API. Use UBLDC's `ubdcc_address=...` parameter to connect as a client.
 
+## Related Articles
+
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours) — 25-hour experiment with a naive depth cache that does not prune levels beyond the top-1000 window; shows how orphaned/stale levels accumulate over time. UBLDC removes those automatically.
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture write-up of the multi-node trust-layer (UBDCC) on top of UBLDC.
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache


### PR DESCRIPTION
## Summary
- Add two new technopathy.club articles to the *Related Articles* section.

## New links
- https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours
- https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books

The rot experiment shows what happens to a naive depth cache without lifecycle pruning — relevant for users comparing UBLDC's behavior. The UBDCC deep-dive frames the multi-node trust-layer follow-up that builds on UBLDC.

## Test plan
- [x] README renders correctly on GitHub
- [x] Link targets are reachable