### PR TITLE
deps: bump unicorn-binance-websocket-api to >=2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.14.0.dev (development stage/unreleased/unstable)
 
+## 2.14.1
+### Changed
+- Bumped minimum `unicorn-binance-websocket-api` dependency from
+  `>=2.12.2` to `>=2.13.0` in `setup.py`, `requirements.txt`,
+  `pyproject.toml`, `environment.yml` and `meta.yaml`. UBWA 2.13.0
+  introduces the per-category Futures WebSocket routing
+  (`/public`, `/market`, `/private`) required by Binance since
+  2026-04-23 and raises `ValueError` on mixed-category streams.
+  See
+  [unicorn-binance-websocket-api#437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437).
+
 ## 2.14.0
 ### Changed
 - **Breaking**: renamed the cluster client's credential methods to drop the

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - orjson
   - requests>=2.32.3
   - unicorn-binance-rest-api>=2.10.0
-  - unicorn-binance-websocket-api>=2.12.2
+  - unicorn-binance-websocket-api>=2.13.0

--- a/meta.yaml
+++ b/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - orjson
     - requests >=2.32.3
     - unicorn-binance-rest-api >=2.10.0
-    - unicorn-binance-websocket-api >=2.12.2
+    - unicorn-binance-websocket-api >=2.13.0
   run:
     - python
     - aiohttp
@@ -35,7 +35,7 @@ requirements:
     - orjson
     - requests >=2.32.3
     - unicorn-binance-rest-api >=2.10.0
-    - unicorn-binance-websocket-api >=2.12.2
+    - unicorn-binance-websocket-api >=2.13.0
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Cython = ">=3.0.10"
 orjson = "*"
 requests = ">=2.32.3"
 unicorn-binance-rest-api = ">=2.10.0"
-unicorn-binance-websocket-api = ">=2.12.2"
+unicorn-binance-websocket-api = ">=2.13.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Cython>=3.0.10
 orjson
 requests>=2.32.3
 unicorn-binance-rest-api>=2.10.0
-unicorn-binance-websocket-api>=2.12.2
+unicorn-binance-websocket-api>=2.13.0

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
      long_description_content_type="text/markdown",
      license='MIT',
      install_requires=['aiohttp', 'Cython>=3.0.10', 'orjson', 'requests>=2.32.3',
-                       'unicorn-binance-websocket-api>=2.12.2', 'unicorn-binance-rest-api>=2.10.0'],
+                       'unicorn-binance-websocket-api>=2.13.0', 'unicorn-binance-rest-api>=2.10.0'],
      keywords='binance, depth cache',
      project_urls={
          'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache',


### PR DESCRIPTION
## Summary

Raises the minimum UBWA pin from `>=2.12.2` to `>=2.13.0` across all suite files (`setup.py`, `requirements.txt`, `pyproject.toml`, `environment.yml`, `meta.yaml`).

## Why

UBWA 2.13.0 introduces the per-category USDT-M Futures WebSocket routing (`/public`, `/market`, `/private`) required by Binance since the 2026-04-23 cutoff, and raises `ValueError` on mixed-category streams. Pinning UBLDC to `>=2.13.0` ensures Futures DepthCaches keep working when Binance fully retires the legacy paths.

Reference: [unicorn-binance-websocket-api#437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437) / [PR #441](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/441).

## Notes

- No version bump in this PR — the pin update will roll out with the next regular UBLDC release.
- CHANGELOG entry added under a `## 2.14.1` placeholder section per the project's dev-stage convention; rename if you bundle this into a different version on release.