### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Version management helper: `dev/set_version.py`
 
 ## Code Conventions
 
-- **File header:** Full MIT license block with author/copyright (2019-2025)
+- **File header:** Full MIT license block with author/copyright (2019-2026)
 - **Encoding:** UTF-8, UNIX line endings
 - **Logging:** `logging.getLogger("unicorn_binance_local_depth_cache")`
 - **Type hints:** Present throughout; `typing` stdlib

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 ===========
 
-Copyright (c) 2019-2025 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
+Copyright (c) 2019-2026 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dev/pypi/create_wheel.sh
+++ b/dev/pypi/create_wheel.sh
@@ -10,9 +10,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 security-check() {

--- a/dev/pypi/install_packaging_tools.sh
+++ b/dev/pypi/install_packaging_tools.sh
@@ -12,9 +12,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 python3 -m pip install --user --upgrade pip setuptools wheel twine tqdm

--- a/dev/pypi/remove_files.sh
+++ b/dev/pypi/remove_files.sh
@@ -12,9 +12,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 rm ./build -r

--- a/dev/pypi/upload_wheel.sh
+++ b/dev/pypi/upload_wheel.sh
@@ -12,9 +12,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # create this file:

--- a/unicorn_binance_local_depth_cache/cluster.py
+++ b/unicorn_binance_local_depth_cache/cluster.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_local_depth_cache/cluster_endpoints.py
+++ b/unicorn_binance_local_depth_cache/cluster_endpoints.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_local_depth_cache/exceptions.py
+++ b/unicorn_binance_local_depth_cache/exceptions.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unittest_binance_local_depth_cache.py
+++ b/unittest_binance_local_depth_cache.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #


### PR DESCRIPTION
## Summary
- Bump copyright year from 2025 to 2026 in LICENSE + source headers
- Pattern: only modify lines containing \`Copyright\` to avoid touching unrelated 2025 occurrences
- Auto-generated files (\`docs/\`, \`dev/sphinx/\`) intentionally untouched — regenerated on next build

## Test plan
- [ ] LICENSE shows 2019-2026
- [ ] No unintended 2025→2026 changes in non-copyright lines