### PR TITLE
examples(ubdcc): add create-{spot,futures}-depthcaches-async.py

### DIFF
--- a/examples/unicorn_binance_depth_cache_cluster/create-futures-depthcaches-async.py
+++ b/examples/unicorn_binance_depth_cache_cluster/create-futures-depthcaches-async.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ¯\_(ツ)_/¯
+#
+# Creates a UBDCC DepthCache with 2 replicas for every active futures market
+# (status == "TRADING") on binance.com-futures.
+
+from dotenv import load_dotenv
+from pprint import pprint
+from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheClusterNotReachableError
+from unicorn_binance_rest_api import BinanceRestApiManager
+import asyncio
+import logging
+import os
+
+load_dotenv()
+
+exchange: str = "binance.com-futures"
+ubdcc_address: str = os.getenv('UBDCC_ADDRESS')
+ubdcc_port: int = int(os.getenv('UBDCC_PORT'))
+
+logging.getLogger("unicorn_binance_local_depth_cache")
+logging.basicConfig(level=logging.ERROR,
+                    filename=os.path.basename(__file__) + '.log',
+                    format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
+                    style="{")
+
+
+async def main():
+    with BinanceRestApiManager(exchange=exchange) as ubra:
+        exchange_info = ubra.futures_exchange_info()
+        markets = [item['symbol'] for item in exchange_info['symbols']
+                   if item['status'] == "TRADING"]
+    result = await ubldc.cluster.create_depthcaches_async(exchange=exchange, markets=markets, desired_quantity=2)
+    print(f"Adding {len(markets)} DepthCaches for exchange '{exchange}' on UBDCC '{ubdcc_address}':")
+    pprint(result)
+
+try:
+    with BinanceLocalDepthCacheManager(exchange=exchange, ubdcc_address=ubdcc_address, ubdcc_port=ubdcc_port) as ubldc:
+        try:
+            asyncio.run(main())
+        except KeyboardInterrupt:
+            print("\r\nGracefully stopping ...")
+        except Exception as error_msg:
+            print(f"ERROR: {error_msg}")
+except DepthCacheClusterNotReachableError as error_msg:
+    print(f"ERROR: {error_msg}")

--- a/examples/unicorn_binance_depth_cache_cluster/create-spot-depthcaches-async.py
+++ b/examples/unicorn_binance_depth_cache_cluster/create-spot-depthcaches-async.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ¯\_(ツ)_/¯
+#
+# Creates a UBDCC DepthCache with 2 replicas for every active spot market
+# (status == "TRADING") on binance.com.
+
+from dotenv import load_dotenv
+from pprint import pprint
+from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheClusterNotReachableError
+from unicorn_binance_rest_api import BinanceRestApiManager
+import asyncio
+import logging
+import os
+
+load_dotenv()
+
+exchange: str = "binance.com"
+ubdcc_address: str = os.getenv('UBDCC_ADDRESS')
+ubdcc_port: int = int(os.getenv('UBDCC_PORT'))
+
+logging.getLogger("unicorn_binance_local_depth_cache")
+logging.basicConfig(level=logging.ERROR,
+                    filename=os.path.basename(__file__) + '.log',
+                    format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
+                    style="{")
+
+
+async def main():
+    with BinanceRestApiManager(exchange=exchange) as ubra:
+        exchange_info = ubra.get_exchange_info()
+        markets = [item['symbol'] for item in exchange_info['symbols']
+                   if item['status'] == "TRADING"]
+    result = await ubldc.cluster.create_depthcaches_async(exchange=exchange, markets=markets, desired_quantity=2)
+    print(f"Adding {len(markets)} DepthCaches for exchange '{exchange}' on UBDCC '{ubdcc_address}':")
+    pprint(result)
+
+try:
+    with BinanceLocalDepthCacheManager(exchange=exchange, ubdcc_address=ubdcc_address, ubdcc_port=ubdcc_port) as ubldc:
+        try:
+            asyncio.run(main())
+        except KeyboardInterrupt:
+            print("\r\nGracefully stopping ...")
+        except Exception as error_msg:
+            print(f"ERROR: {error_msg}")
+except DepthCacheClusterNotReachableError as error_msg:
+    print(f"ERROR: {error_msg}")


### PR DESCRIPTION
## Summary
Two new UBDCC example scripts under
`examples/unicorn_binance_depth_cache_cluster/`:

- **`create-spot-depthcaches-async.py`**: fetches every active spot
  market (`status == "TRADING"`) on `binance.com` via UBRA's
  `get_exchange_info()` and registers a UBDCC DepthCache per symbol
  with `desired_quantity=2`.
- **`create-futures-depthcaches-async.py`**: same flow against
  `binance.com-futures` via `futures_exchange_info()`.

Both use `ubldc.cluster.create_depthcaches_async()` so the bulk
request scales for the full Binance symbol set (~2.5k spot,
~600 futures). UBDCC endpoint + port read from `UBDCC_ADDRESS` /
`UBDCC_PORT` env vars — same dotenv pattern as the existing
examples in this folder.

## Test plan
- [ ] `.env` with valid `UBDCC_ADDRESS` / `UBDCC_PORT` pointing at a
      running UBDCC cluster
- [ ] `python create-spot-depthcaches-async.py` → all spot symbols
      registered, each with 2 replicas
- [ ] `python create-futures-depthcaches-async.py` → same for futures