### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,4 +198,6 @@ ubldc = BinanceLocalDepthCacheManager(exchange="binance.com", ubra_manager=ubra)
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## LUCIT-Systems-and-Development origin
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
-**Confirmed** (git history; old LUCIT-org issue URLs in early commits, e.g. `1282d45`, `005b68f`)
+**Evidence:** confirmed
+**Source:** git history; old LUCIT-org issue URLs in early commits, e.g. `1282d45`, `005b68f`
 
 Same origin and cleanup pattern as the rest of the suite: de-branded from `LUCIT-Systems-and-Development`, moved to `oliver-zehentleitner`, conda distribution switched to conda-forge with the in-repo `build_conda.yml` workflow removed (commit `eb0ca0f`, 2026-04-18: "Switch conda references to conda-forge, clean meta.yaml, sync deps").
 
@@ -12,7 +13,8 @@ Same origin and cleanup pattern as the rest of the suite: de-branded from `LUCIT
 ## Cluster-client method rename (2.14.0)
 
 **Status:** active
-**Confirmed** (commit `4b29780`)
+**Evidence:** confirmed
+**Source:** commit `4b29780`
 
 `ubdcc_*_credentials` methods on the cluster client had the `ubdcc_` prefix dropped, paired with matching endpoint renames on the UBDCC side (requires `ubdcc >= 0.7.0`).
 

--- a/context/sync.md
+++ b/context/sync.md
@@ -3,7 +3,8 @@
 ## Options depth cache: endless resync from a stale REST snapshot
 
 **Status:** active
-**Confirmed** (commit `f57089f`)
+**Evidence:** confirmed
+**Source:** commit `f57089f`
 
 Binance's `/eapi/v1/depth` REST endpoint (used for `binance.com-vanilla-options` snapshots) can serve a cached response whose `lastUpdateId` lags the live WebSocket diff stream by up to ~25–30 seconds. The standard Binance sync algorithm requires finding a diff event where `U <= lastUpdateId <= u`; with a snapshot that stale, that predicate could never match, and the old code discarded the init buffer on every resync attempt — producing an endless "out of sync" loop for options markets specifically.
 
@@ -14,7 +15,8 @@ Binance's `/eapi/v1/depth` REST endpoint (used for `binance.com-vanilla-options`
 ## Init-race: buffer WS events instead of dropping them
 
 **Status:** active
-**Confirmed** (commit `fc7afdd`)
+**Evidence:** confirmed
+**Source:** commit `fc7afdd`
 
 During the snapshot-fetch window (before `last_update_id` is known), WebSocket diff events arriving in that gap were previously dropped rather than buffered — risking a missed sync point, especially on fast-moving markets where several diffs can arrive before the REST snapshot response comes back.
 
@@ -23,7 +25,8 @@ During the snapshot-fetch window (before `last_update_id` is known), WebSocket d
 ## Margin/isolated-margin: falling through to the wrong path in four places
 
 **Status:** active
-**Confirmed** (commit `106b73c`)
+**Evidence:** confirmed
+**Source:** commit `106b73c`
 
 Margin and isolated-margin exchanges were falling through to an `else` branch in four separate places: `_get_order_book_from_rest()`, live-update gap detection, post-sync replay gap detection, and `_process_init_event()` — none of which routed them into the actual sync logic.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.