### PR TITLE
chore(ktw): bump context-schema to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,6 @@ ubldc = BinanceLocalDepthCacheManager(exchange="binance.com", ubra_manager=ubra)
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.1
+- context-schema: 0.8.0
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -24,6 +24,7 @@ For usage, installation, operation, or troubleshooting, see `docs/`.
 
 Each entry separates:
 
+- **Type** — what kind of thing it is: decision, workaround, incident, or constraint (or undefined, with a reason, if none fit)
 - **Status** — whether a decision is active, superseded, open, or needs review
 - **Evidence** — whether its rationale is confirmed, inferred, or unknown
 

--- a/context/history.md
+++ b/context/history.md
@@ -2,6 +2,7 @@
 
 ## LUCIT-Systems-and-Development origin
 
+**Type:** decision
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
 **Evidence:** confirmed
 **Source:** git history; old LUCIT-org issue URLs in early commits, e.g. `1282d45`, `005b68f`
@@ -12,6 +13,7 @@ Same origin and cleanup pattern as the rest of the suite: de-branded from `LUCIT
 
 ## Cluster-client method rename (2.14.0)
 
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `4b29780`

--- a/context/sync.md
+++ b/context/sync.md
@@ -2,6 +2,7 @@
 
 ## Options depth cache: endless resync from a stale REST snapshot
 
+**Type:** incident
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `f57089f`
@@ -14,6 +15,7 @@ Binance's `/eapi/v1/depth` REST endpoint (used for `binance.com-vanilla-options`
 
 ## Init-race: buffer WS events instead of dropping them
 
+**Type:** incident
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `fc7afdd`
@@ -24,6 +26,7 @@ During the snapshot-fetch window (before `last_update_id` is known), WebSocket d
 
 ## Margin/isolated-margin: falling through to the wrong path in four places
 
+**Type:** incident
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `106b73c`


### PR DESCRIPTION
Migrates the project's keep-the-why context-schema from its previous value to 0.8.0.

- Bumps `context-schema` in AGENTS.md.
- Adds the Type field line to `context/README.md`'s "Reading the entries" section (0.7.0/0.8.0 migration step).

Individual context/ entries are not backfilled in bulk — per the skill's migration guidance, an entry picks up a Type value the next time it's touched anyway, not as a dedicated pass.